### PR TITLE
Support building with system version of some dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,11 @@ option(SDFLIB_USE_ASSIMP "Use assimp library for importing models" ON)
 option(SDFLIB_USE_OPENMP "Use OpenMP for accelerate the structures construction" ON)
 option(SDFLIB_USE_ENOKI "Use Enoki for some optimizations" ON)
 
+option(SDFLIB_USE_SYSTEM_GLM "Use glm library via find_package instead of downloading it" OFF)
+option(SDFLIB_USE_SYSTEM_SPDLOG "Use spdlog library via find_package instead of downloading it" OFF)
+option(SDFLIB_USE_SYSTEM_CEREAL "Use cereal library via find_package instead of downloading it" OFF)
+option(SDFLIB_USE_SYSTEM_ASSIMP "Use assimp library via find_package instead of downloading it" OFF)
+
 
 if(SDFLIB_DEBUG_INFO)
     add_compile_definitions(SDFLIB_PRINT_STATISTICS)
@@ -73,6 +78,19 @@ endforeach()
 add_custom_target(copyShaders ALL SOURCES ${SHADER_FILES})
 
 # Add dependencies
+if(SDFLIB_USE_SYSTEM_ASSIMP)
+    find_package(assimp REQUIRED)
+endif()
+if(SDFLIB_USE_SYSTEM_SPDLOG)
+    find_package(spdlog REQUIRED)
+endif()
+if(SDFLIB_USE_SYSTEM_CEREAL)
+    find_package(cereal REQUIRED)
+endif()
+if(SDFLIB_USE_SYSTEM_GLM)
+    find_package(glm REQUIRED)
+    set(SDFLIB_GLM_TARGET glm::glm)
+endif()
 add_subdirectory(libs)
 
 if(SDFLIB_USE_ENOKI)
@@ -82,7 +100,7 @@ if(SDFLIB_USE_ENOKI)
 endif()
 
 if(SDFLIB_USE_ASSIMP)
-    target_link_libraries(${PROJECT_NAME} PUBLIC assimp)
+    target_link_libraries(${PROJECT_NAME} PUBLIC assimp::assimp)
     target_compile_definitions(${PROJECT_NAME} PUBLIC -DSDFLIB_ASSIMP_AVAILABLE)
 endif()
 
@@ -91,9 +109,9 @@ if(SDFLIB_BUILD_APPS OR SDFLIB_BUILD_DEBUG_APPS)
     target_link_libraries(${PROJECT_NAME} PUBLIC stb_image)
 endif()
     
-target_link_libraries(${PROJECT_NAME} PUBLIC glm)
-target_link_libraries(${PROJECT_NAME} PUBLIC spdlog)
-target_link_libraries(${PROJECT_NAME} PUBLIC cereal)
+target_link_libraries(${PROJECT_NAME} PUBLIC ${SDFLIB_GLM_TARGET})
+target_link_libraries(${PROJECT_NAME} PUBLIC spdlog::spdlog)
+target_link_libraries(${PROJECT_NAME} PUBLIC cereal::cereal)
 target_link_libraries(${PROJECT_NAME} PUBLIC icg)
 
 if(CMAKE_CXX_COMPILER_ID MATCHES GNU)

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -2,36 +2,41 @@ include(FetchContent)
 set(CMAKE_POLICY_DEFAULT_CMP0048 NEW)
 
 # glm
-FetchContent_Declare(glm_lib
-  GIT_REPOSITORY https://github.com/g-truc/glm.git
-  GIT_TAG 89e52e327d7a3ae61eb402850ba36ac4dd111987 # 0.9.8
-)
+if(NOT SDFLIB_USE_SYSTEM_GLM)
+	FetchContent_Declare(glm_lib
+	  GIT_REPOSITORY https://github.com/g-truc/glm.git
+	  GIT_TAG 89e52e327d7a3ae61eb402850ba36ac4dd111987 # 0.9.8
+	)
 
-FetchContent_GetProperties(glm_lib)
-if(NOT glm_lib_POPULATED)
-	FetchContent_Populate(glm_lib)
-	add_subdirectory(${glm_lib_SOURCE_DIR} ${glm_lib_BINARY_DIR})
+	FetchContent_GetProperties(glm_lib)
+	if(NOT glm_lib_POPULATED)
+		FetchContent_Populate(glm_lib)
+		add_subdirectory(${glm_lib_SOURCE_DIR} ${glm_lib_BINARY_DIR})
+	endif()
+	set(SDFLIB_GLM_TARGET glm PARENT_SCOPE)
 endif()
 
 # assimp
 if(SDFLIB_USE_ASSIMP)
-	FetchContent_Declare(assimp_lib
-	  GIT_REPOSITORY https://github.com/assimp/assimp.git
-	  GIT_TAG 9519a62dd20799c5493c638d1ef5a6f484e5faf1 # 5.2.5
-	)
+	if(NOT SDFLIB_USE_SYSTEM_ASSIMP)
+		FetchContent_Declare(assimp_lib
+		  GIT_REPOSITORY https://github.com/assimp/assimp.git
+		  GIT_TAG 9519a62dd20799c5493c638d1ef5a6f484e5faf1 # 5.2.5
+		)
 	
-	if(NOT assimp_lib)
-		FetchContent_Populate(assimp_lib)
+		if(NOT assimp_lib)
+			FetchContent_Populate(assimp_lib)
 		
-		set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
-		set(BUILD_SHARED_LIBS OFF)
-		set(ASSIMP_BUILD_ASSIMP_TOOLS OFF)
-		set(ASSIMP_BUILD_TESTS OFF)
-		set(ASSIMP_INSTALL OFF)
-		set(ASSIMP_INJECT_DEBUG_POSTFIX OFF)
-		set(ASSIMP_BUILD_ASSIMP_VIEW OFF)
+			set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
+			set(BUILD_SHARED_LIBS OFF)
+			set(ASSIMP_BUILD_ASSIMP_TOOLS OFF)
+			set(ASSIMP_BUILD_TESTS OFF)
+			set(ASSIMP_INSTALL OFF)
+			set(ASSIMP_INJECT_DEBUG_POSTFIX OFF)
+			set(ASSIMP_BUILD_ASSIMP_VIEW OFF)
 		
-		add_subdirectory(${assimp_lib_SOURCE_DIR} ${assimp_lib_BINARY_DIR})
+			add_subdirectory(${assimp_lib_SOURCE_DIR} ${assimp_lib_BINARY_DIR})
+		endif()
 	endif()
 endif()
 
@@ -51,32 +56,36 @@ if(SDFLIB_BUILD_APPS OR SDFLIB_BUILD_DEBUG_APPS)
  endif()
 
 # spdlog
-FetchContent_Declare(spdlog_lib
-  GIT_REPOSITORY https://github.com/gabime/spdlog.git
-  GIT_TAG eb3220622e73a4889eee355ffa37972b3cac3df5 # 1.9.2
-)
+if(NOT SDFLIB_USE_SYSTEM_SPDLOG)
+	FetchContent_Declare(spdlog_lib
+	  GIT_REPOSITORY https://github.com/gabime/spdlog.git
+	  GIT_TAG eb3220622e73a4889eee355ffa37972b3cac3df5 # 1.9.2
+	)
 
-FetchContent_GetProperties(spdlog_lib)
-if(NOT spdlog_lib_POPULATED)
-	FetchContent_Populate(spdlog_lib)
-	add_subdirectory(${spdlog_lib_SOURCE_DIR} ${spdlog_lib_BINARY_DIR})
+	FetchContent_GetProperties(spdlog_lib)
+	if(NOT spdlog_lib_POPULATED)
+	   FetchContent_Populate(spdlog_lib)
+	   add_subdirectory(${spdlog_lib_SOURCE_DIR} ${spdlog_lib_BINARY_DIR})
+	endif()
 endif()
 
 # cereal
-FetchContent_Declare(cereal_lib
-  GIT_REPOSITORY https://github.com/USCiLab/cereal.git
-  GIT_TAG ebef1e929807629befafbb2918ea1a08c7194554 # 1.3.2
-)
+if(NOT SDFLIB_USE_SYSTEM_CEREAL)
+	FetchContent_Declare(cereal_lib
+	  GIT_REPOSITORY https://github.com/USCiLab/cereal.git
+	  GIT_TAG ebef1e929807629befafbb2918ea1a08c7194554 # 1.3.2
+	)
 
-FetchContent_GetProperties(cereal_lib)
-if(NOT cereal_lib_POPULATED)
-	FetchContent_Populate(cereal_lib)
-	set(BUILD_DOC OFF)
-	set(BUILD_SANDBOX  OFF)
-	set(BUILD_TESTS OFF)
-	set(CEREAL_INSTALL OFF)
-	set(SKIP_PERFORMANCE_COMPARISON ON)
-	add_subdirectory(${cereal_lib_SOURCE_DIR} ${cereal_lib_BINARY_DIR})
+	FetchContent_GetProperties(cereal_lib)
+	if(NOT cereal_lib_POPULATED)
+		FetchContent_Populate(cereal_lib)
+		set(BUILD_DOC OFF)
+		set(BUILD_SANDBOX  OFF)
+		set(BUILD_TESTS OFF)
+		set(CEREAL_INSTALL OFF)
+		set(SKIP_PERFORMANCE_COMPARISON ON)
+		add_subdirectory(${cereal_lib_SOURCE_DIR} ${cereal_lib_BINARY_DIR})
+	endif()
 endif()
 
 # Enoki


### PR DESCRIPTION
Support building with system version of:
* assimp
* glm
* cereal
* spdlog

I choose to first tackle this, as they are the one required for the library itself, and they provide well-formed CMake config files for which it is possible to do `find_package(<package> ...)`

Related to: https://github.com/UPC-ViRVIG/SdfLib/issues/8 .