### PR TITLE
Update spdlog to 1.15.3

### DIFF
--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -62,7 +62,7 @@ if(SDFLIB_BUILD_APPS OR SDFLIB_BUILD_DEBUG_APPS)
 if(NOT SDFLIB_USE_SYSTEM_SPDLOG)
 	FetchContent_Declare(spdlog_lib
 	  GIT_REPOSITORY https://github.com/gabime/spdlog.git
-	  GIT_TAG eb3220622e73a4889eee355ffa37972b3cac3df5 # 1.9.2
+	  GIT_TAG 6fa36017cfd5731d617e1a934f0e5ea9c4445b13 # 1.15.3
 	)
 
 	FetchContent_GetProperties(spdlog_lib)


### PR DESCRIPTION
In order to compile SdfLib on Alpine Linux (which uses the musl libc), a newer version of spdlog is required. Specifically, this is the required commit in spdlog: https://github.com/gabime/spdlog/commit/287a00d364990edbb621fe5e392aeb550135fb96